### PR TITLE
AMB-1339 fix issue with examples not getting rendered

### DIFF
--- a/specification/service-search-api.yaml
+++ b/specification/service-search-api.yaml
@@ -417,8 +417,9 @@ components:
       description: Not found
       content:
         application/json:
-          example:
-            $ref: "examples/organisations-not-found_v2.json"
+          examples:
+            OrganisationNotFound:
+              $ref: "examples/organisations-not-found_v2.json"
           schema:
             type: object
             properties: { }
@@ -447,8 +448,9 @@ components:
       description: Postcode search results
       content:
         "application/json":
-          example:
-            $ref: "examples/search-postcode_v2.json"
+          examples:
+            SearchPostcodeV2:
+              $ref: "examples/search-postcode_v2.json"
           schema:
             type: object
             properties:


### PR DESCRIPTION
use only examples
openapi-generator-cli doesn't inline "example" field but when using "examples" it's inlining them.

## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

Add any other relevant notes or explanations here. **Remove this line if you have nothing to add.**


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
