### PR TITLE
remove duplicate publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ copy-examples:
 	cp specification/examples/* sandbox/responses/
 
 #Create /dist/ sub-directory and copy files into directory
-release: clean copy-examples publish build-proxy
+release: clean copy-examples build-proxy
 	mkdir -p dist
 	for f in $(_dist_include); do cp -r $$f dist; done
 	cp ecs-proxies-deploy.yml dist/ecs-deploy-sandbox.yml


### PR DESCRIPTION
The second publish command is duplicate of the previous pipeline stage